### PR TITLE
fix README for mpas-bundle

### DIFF
--- a/README
+++ b/README
@@ -29,7 +29,7 @@ Note: ecbuild accepts all cmake flags, for example, compilers can be selected wi
 
 To run the mpas-jedi ctests (from build directory):
 
-    cd mpasjedi
+    cd mpas-jedi
     ctest
 
 
@@ -44,7 +44,7 @@ After the first build, changes in the code can be tested by re-running only
 (from build directory):
 
     make -j4
-    cd mpasjedi
+    cd mpas-jedi
     ctest
 
 By default, make will not update your local repository from the remote. To update all repositories

--- a/README
+++ b/README
@@ -6,7 +6,7 @@ which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 #--- Building the mpas-jedi bundle ---
 #
 #    cd /somewhere/to/store/source/code
-#    git clone https://github.com/JCSDA-internal/mpas-bundle.git
+#    git clone https://github.com/JCSDA/mpas-bundle.git
 #
 #    # (If building on Cheyenne)
 #    source mpas-bundle/env-setup/<desired compiler-mpi script>


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: mpas-bundle, README

Jamie noticed that the README instructions are out of date, asking users to  "cd mpasjedi" before running ctest.  This replaces "mpasjedi" with "mpas-jedi" in two places.

LIST OF MODIFIED FILES: README
