### PR TITLE
Add support for iodaconv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Usage: cmake <mpas-bundle src dir> -DCMAKE_BUILD_TYPE=RelWithDebINfo -DCMAKE_VERBOSE_MAKEFILE=ON -DMPAS_DOUBLE_PRECISION=OFF
 
 cmake_minimum_required( VERSION 3.14 )
-project( mpas-bundle VERSION 3.0.0 LANGUAGES C CXX Fortran )
+project( mpas-bundle VERSION 4.0.0 LANGUAGES C CXX Fortran )
 
 ## ECBuild integration
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ _**For performance and memory reasons, it is recommended to compile ```mpas-bund
   |:------------:|:--------------:|:----------------:|
   | __zsh/bash__ | `source <mpas_bundle_dir>/env-setup/gnu-derecho.sh` | `source <mpas_bundle_dir>/env-setup/intel-derecho.sh` |
   | __csh/tcsh__ | `source <mpas_bundle_dir>/env-setup/gnu-derecho.csh` | `source <mpas_bundle_dir>/env-setup/intel-derecho.csh` |
+
+  If you want to run the tests for the ioda converters, `source <mpas_bundle_dir>/env-setup/ioda-modules.list` for any shell.
+
 * Create and navigate into the build directory.
 
   ```bash
@@ -74,8 +77,9 @@ _**For performance and memory reasons, it is recommended to compile ```mpas-bund
   The default setting for `MPAS_DOUBLE_PRECISION` is `ON`.
   
   ```bash
-  cmake <mpas_bundle_dir> -DMPAS_DOUBLE_PRECISION=<ON|OFF> <cmake_flags>
+  cmake <mpas_bundle_dir> -DMPAS_DOUBLE_PRECISION=<ON|OFF>  [ -DBUILD_IODA_CONVERTERS=ON ] <cmake_flags>
   ```
+  Only provide `-DBUILD_IODA_CONVERTERS=ON` if you need the ioda converters built.
 
   Though not required, you can pass flags to cmake that define the build type, makefile
   verbosity, build engine, and compiler flags. A table of useful CMake flags can be found [here](#useful-cmake-flags).
@@ -100,6 +104,14 @@ _**Due to resource limitations, it's recommended to build and run tests on a com
   ```
   ```bash
   qsub ctest.pbs.sh
+  ```
+
+* If you built the ioda converters, generate a batch job for running the ioda converters test suite and submit it using ```qsub```
+  ```bash
+  <mpas_bundle_dir>/env-setup/run_make.bundle.sh -A <derecho_account> -c <compiler> -x ctest-ioda -n
+  ```
+  ```bash
+  qsub ctest-ioda.pbs.sh
   ```
 
 ### Building in an Interactive Session
@@ -130,6 +142,15 @@ _**Due to resource limitations, it's recommended to build and run tests on a com
   However, ctest supports numerous flags that allow you to customize the test execution. For a table of
   useful ```ctest```
   flags, click [here](#useful-ctest-flags).
+
+  If you built the ioda converters, when ```mpas-bundle``` is finished building, enter the ```iodaconv``` build directory 
+  ```bash
+  cd <mpas_bundle_build_dir>/iodaconv
+  ```
+  and run ctest. 
+  ```bash
+  ctest -R "ncar|satbias|iodaconv_bufr|_dpr_gpm|amsr2_gcom|_gmi_gpmiodaconv_atms|iodaconv_tropics|_gnssaro_netcdf_conv" <ctest_flags>
+  ```
 
 ### Useful CMake Flags
 

--- a/env-setup/intel-derecho.csh
+++ b/env-setup/intel-derecho.csh
@@ -36,6 +36,9 @@ module load parallelio/2.6.2
 module load gsl-lite/0.37.0
 module load nccmp/1.9.0.1
 module load udunits/2.2.28
+# Following modules are required for ioda-converters build
+module load bufr/12.1.0
+module load py-pybind11/2.13.5
 module list
 
 limit stacksize unlimited

--- a/env-setup/intel-derecho.sh
+++ b/env-setup/intel-derecho.sh
@@ -33,6 +33,9 @@ module load parallelio/2.6.2
 module load gsl-lite/0.37.0
 module load nccmp/1.9.0.1
 module load udunits/2.2.28
+# Following modules are required for ioda-converters build
+module load bufr/12.1.0
+module load py-pybind11/2.13.5
 module list
 
 ulimit -s unlimited

--- a/env-setup/ioda-modules.list
+++ b/env-setup/ioda-modules.list
@@ -1,0 +1,15 @@
+# Following modules are needed to run the ioda-converters ctests
+module load py-netcdf4/1.7.1.post2
+module load py-h5py/3.12.1
+module load py-python-dateutil/2.8.2
+module load py-xarray/2024.7.0
+module load py-pyhdf/0.11.4
+module load py-scipy/1.14.1
+module load py-pyyaml/6.0.2
+module load py-cartopy/0.24.1
+module load py-eccodes/1.5.0
+module load py-pyproj/3.7.0
+
+module list
+
+

--- a/env-setup/run_make.bundle.sh
+++ b/env-setup/run_make.bundle.sh
@@ -47,13 +47,13 @@ export GFORTRAN_CONVERT_UNIT='big_endian:101-200'
 
 usage()
 {
-	echo "usage: $0 -A account -c gnu|intel|nvhpc [-x make|ctest|both|echo] [-l] "
+	echo "usage: $0 -A account -c gnu|intel|nvhpc [-x make|ctest|ctest-ioda|both|echo] [-l] "
 	echo "  [-q queue] [-p priority][-t threads] [-N name] [-f job-file] [-m] [-n] [-e env-dir] [-h] "
 	echo
 	echo "  account is the HPC account number"
 	echo "  -c <compiler> is one of [ $DERECHO_CC ]"
 	echo "  -x to specify what to run, default is -x $DEFAULT_EXEC"
-  echo "      both will submit one job which will run make and run ctest"
+  echo "      both will submit one job which will run make and run mpas-jedi ctest"
 	echo "      use echo to submit a job which only sets the environment (for testing)"
 	echo "  -l: wait for job to start and log progress"
 	echo "  -q queue is one of [ ${QUEUE_OPTS[@]} ], default is $QUEUE"
@@ -171,10 +171,16 @@ if [ "$VERBOSE" != "" ]; then
   echo modfile:$MODFILE
 fi
 
+IODA_MODS=""
+IODA_ARGS="-R \"ncar|satbias|iodaconv_bufr|_dpr_gpm|amsr2_gcom|_gmi_gpmiodaconv_atms|iodaconv_tropics|_gnssaro_netcdf_conv\" "
 if [ "$DEFAULT_EXEC" == "make" ]; then
 	EXEC="$DEFAULT_EXEC -j$NTHREADS"
 elif [ "$DEFAULT_EXEC" == "ctest" ]; then
 	EXEC="cd mpas-jedi && ctest"
+elif [ "$DEFAULT_EXEC" == "ctest-ioda" ]; then
+	EXEC="cd iodaconv && ctest $IODA_ARGS"
+  IODA_MODS="${ENV_DIR}/ioda-modules.list"
+  NAME="ioda-ctest"
 elif [ "$DEFAULT_EXEC" == "both" ]; then
 	EXEC="make -j$NTHREADS && cd mpas-jedi && ctest"
 elif [ "$DEFAULT_EXEC" == "echo" ]; then
@@ -194,7 +200,7 @@ cat > $JOB_FILE << EOF
 #PBS -j oe
 #PBS -k eod
 #--- get 1 cpu per thread
-#PBS -l select=1:ncpus=$NTHREADS:mem=32GB
+#PBS -l select=1:ncpus=$NTHREADS:mem=${NTHREADS}GB
 #PBS -l job_priority=$PRIORITY
 #--- 
 #PBS -N $NAME
@@ -207,7 +213,11 @@ date
 EOF
 
 cat $MODFILE >> $JOB_FILE
+if [ "$IODA_MODS" != "" ]; then
+  cat $IODA_MODS >> $JOB_FILE
+fi
 echo $EXEC >> $JOB_FILE
+
 
 # submit the job to a compute node
 if [ "$RUN" = "" ]; then

--- a/env-setup/run_make.bundle.sh
+++ b/env-setup/run_make.bundle.sh
@@ -177,6 +177,9 @@ if [ "$DEFAULT_EXEC" == "make" ]; then
 	EXEC="$DEFAULT_EXEC -j$NTHREADS"
 elif [ "$DEFAULT_EXEC" == "ctest" ]; then
 	EXEC="cd mpas-jedi && ctest"
+	if [ "$COMPILER" == "intel" ]; then
+    EXEC+=" -LE ci_oneapi_disable"
+  fi
 elif [ "$DEFAULT_EXEC" == "ctest-ioda" ]; then
 	EXEC="cd iodaconv && ctest $IODA_ARGS"
   IODA_MODS="${ENV_DIR}/ioda-modules.list"


### PR DESCRIPTION
This PR adds support for running ithe ctests for the ioda converters.
It also updates the instructions to explain how to build the ioda converters, as well as how to run the ioda converter ctests.
The mpas-bundle version is set to 4.0.0

TYPE: enhancement, new feature

KEYWORDS: obs2ioda, ioda converters

LIST OF MODIFIED FILES:
M       CMakeLists.txt
M       README.md
A       env-setup/intel-derecho.csh
A       env-setup/intel-derecho.sh
A       env-setup/ioda-modules.list
M       env-setup/run_make.bundle.sh

TESTS CONDUCTED:
Ran cmake with `-DBUILD_IODA_CONVERTERS=ON`
Ran the mpas-bundle ctests.
Ran the ioda converter ctests.