### PR TITLE
Use tag 1.0.0 for the iodaconv repository.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ else()
     # Build IODA converters if requested
     option(BUILD_IODA_CONVERTERS "Build IODA Converters" OFF)
     if(BUILD_IODA_CONVERTERS)
-        ecbuild_bundle( PROJECT iodaconv GIT "https://github.com/jcsda-internal/ioda-converters.git" TAG f62d401 )
+        ecbuild_bundle( PROJECT iodaconv GIT "https://github.com/jcsda-internal/ioda-converters.git" TAG 1.0.0 )
     endif()
 
     # Find external ESMF for mpas-model (optional)


### PR DESCRIPTION
The iodaconv repository has a new tag for release 1.0.0.
This is used for jedi-bundle 2026.1.
This PR uses tag 1.0.0 when extracting the iodaconv repository.

TYPE: enhancement
KEYWORDS: cmake

LIST OF MODIFIED FILES: CMakeLists.txt
TESTS CONDUCTED:
1. ran cmake
2. ran the iodaconv ctests.